### PR TITLE
Fix mime type errors

### DIFF
--- a/SleepUino/data/index.html
+++ b/SleepUino/data/index.html
@@ -127,6 +127,7 @@
             // add SleepUinoTests.js to DOM
             const script = document.createElement('script')
             script.src = './SleepUinoTests.js'
+            script.type = "application/javascript"
             document.head.append(script)
 
             console.log("Enable Dummy Interface")

--- a/SleepUino/data/index.html
+++ b/SleepUino/data/index.html
@@ -3,15 +3,15 @@
 <head>
     <title>SleepUino</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="stylesheet" href="css/TestTheme.min.css" />
-    <link rel="stylesheet" href="css/jquery.mobile.icons.min.css" />
-    <link rel="stylesheet" href="css/jquery.mobile.struc.min.css" />
-    <link rel="stylesheet" href="css/sleepUino.css" />
-    <script src="./jquery-2.2.4.min.js"></script>
-    <script src="./jquery.mobile-1.4.5.min.js"></script>
-    <script src="./myFunctions.js"></script>
-    <script src="./SleepUinoCom.js"></script>
-    <script src="./multiLangSupport.js"></script>
+    <link rel="stylesheet" href="css/TestTheme.min.css" type="text/css"/>
+    <link rel="stylesheet" href="css/jquery.mobile.icons.min.css" type="text/css"/>
+    <link rel="stylesheet" href="css/jquery.mobile.struc.min.css" type="text/css"/>
+    <link rel="stylesheet" href="css/sleepUino.css" type="text/css"/>
+    <script type="application/javascript" src="./jquery-2.2.4.min.js"></script>
+    <script type="application/javascript" src="./jquery.mobile-1.4.5.min.js"></script>
+    <script type="application/javascript" src="./myFunctions.js"></script>
+    <script type="application/javascript" src="./SleepUinoCom.js"></script>
+    <script type="application/javascript" src="./multiLangSupport.js"></script>
 </head>
 <body> 
     <div class="su-base" data-role="page" class="ui-responsive-panel" id="page">

--- a/SleepUino/data/index.html
+++ b/SleepUino/data/index.html
@@ -12,6 +12,7 @@
     <script type="application/javascript" src="./myFunctions.js"></script>
     <script type="application/javascript" src="./SleepUinoCom.js"></script>
     <script type="application/javascript" src="./multiLangSupport.js"></script>
+    <script type="application/javascript" src="./SleepUinoTests.js"></script>
 </head>
 <body> 
     <div class="su-base" data-role="page" class="ui-responsive-panel" id="page">
@@ -125,10 +126,10 @@
         {
             SleepUinoCom.enableServerCom = false;
             // add SleepUinoTests.js to DOM
-            const script = document.createElement('script')
-            script.src = './SleepUinoTests.js'
-            script.type = "application/javascript"
-            document.head.append(script)
+            // const script = document.createElement('script')
+            // script.src = './SleepUinoTests.js'
+            // script.type = "application/javascript"
+            // document.head.append(script)
 
             console.log("Enable Dummy Interface")
         },

--- a/SleepUino/data/index.html
+++ b/SleepUino/data/index.html
@@ -9,6 +9,9 @@
     <link rel="stylesheet" href="css/sleepUino.css" />
     <script src="./jquery-2.2.4.min.js"></script>
     <script src="./jquery.mobile-1.4.5.min.js"></script>
+    <script src="./myFunctions.js"></script>
+    <script src="./SleepUinoCom.js"></script>
+    <script src="./multiLangSupport.js"></script>
 </head>
 <body> 
     <div class="su-base" data-role="page" class="ui-responsive-panel" id="page">
@@ -111,9 +114,6 @@
             </div>
         </div>
 </body>
-<script src="./myFunctions.js"></script>
-<script src="./SleepUinoCom.js"></script>
-<script src="./multiLangSupport.js"></script>
 <script>
     'use strict';
     //For test without SleepUINO use SleepUinoCom.enableServerCom = false


### PR DESCRIPTION
With the htmlpreview.js it is not possible to load java script files dynamically.
Now, the fiel SleepUinoTests.js is loaded in the header this will failing if it is used on the SleepUino it self, maybe it can be fixed be the build script