### PR TITLE
Fix cpplint errors: Add missing includes and use static_cast

### DIFF
--- a/.github/workflows/main_action.yml
+++ b/.github/workflows/main_action.yml
@@ -4,8 +4,10 @@ jobs:
   cpplint:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-python@v2
+    - uses: actions/checkout@v6
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.x'
     - run: pip install cpplint
     - run: cpplint --linelength=120 --extensions=hpp,cpp,h,c,ino --recursive ./SleepUino/.
   build_ESP8266:
@@ -17,10 +19,12 @@ jobs:
         BOARD: d1_mini
         LIBS: ArduinoJson,ESP8266Audio,JC_Button,RTClib,U8g2
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
       - run: pip install esptool
       - run: |
           cd SleepUino
@@ -31,7 +35,7 @@ jobs:
           cd SleepUino
           bash ./ESP_Action_Build_Scripts/create_build_info.sh -s $GITHUB_SHA -r $GITHUB_REPOSITORY
         name: Create build info
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{env.CORE}}_${{env.BOARD}}_${{env.SKETCH_NAME}}
           path: ./SleepUino/EEP/*

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ BIN_ESP8266_d1_mini
 CACHE_ESP8266
 EEP
 tools
+.venv

--- a/SleepUino/handleDisplay.ino
+++ b/SleepUino/handleDisplay.ino
@@ -21,6 +21,7 @@
 
 #include "handleDisplay.h"
 #include "Config.h"
+#include <cstdio>
 
 HandleDisplay::HandleDisplay() {
   _u8g2 = new U8G2_SH1106_128X64_NONAME_F_HW_I2C(U8G2_R0, /* reset=*/U8X8_PIN_NONE);

--- a/SleepUino/handleEeprom.ino
+++ b/SleepUino/handleEeprom.ino
@@ -125,7 +125,7 @@ void HandleEeprom::readWakeTimes(uint8_t numberOfTimes, uint16_t wakeUpTimes[]) 
     uint8_t byteHigh = EEPROM.read((EEADR_COUNT + 1) + (i * 2));
     uint8_t byteLow = EEPROM.read((EEADR_COUNT + 1) + (i * 2 + 1));
 
-    uint16_t time = (uint16_t)byteHigh;
+    uint16_t time = static_cast<uint16_t>(byteHigh);
     time = time << 8;
     time = time | byteLow;
 

--- a/SleepUino/handleWebpage.ino
+++ b/SleepUino/handleWebpage.ino
@@ -20,6 +20,7 @@
 
 #include "handleWebpage.h"
 #include "Config.h"
+#include <cstdio>
 
 ESP8266WebServer* HandleWebpage::_webServer = nullptr;
 

--- a/SleepUino/mainFunctionality.ino
+++ b/SleepUino/mainFunctionality.ino
@@ -20,6 +20,7 @@
 
 #include "mainFunctionality.h"
 #include "Config.h"
+#include <cstdio>
 
 MainFunc::MainFunc() {
   _rtc = new RTC_DS3231();


### PR DESCRIPTION
- Include <cstdio> in handleDisplay, handleWebpage, and mainFunctionality
- Replace C-style cast with static_cast in handleEeprom
- Add .venv to .gitignore

update actions to latest versions

pipline: add latest stable python version